### PR TITLE
Remove ensemblesim

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,5 @@
 *.jl~
 Manifest.toml
 *.toml~
-src/old_code.jl
+src/old_code*
 examples/ornstein_uhlenbeck_algorithm_orig.jl

--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,7 @@ name = "RareEvents"
 [deps]
 ClimaCore = "d414da3d-4745-48bb-8d80-42e94e092884"
 DifferentialEquations = "0c46a032-eb83-5123-abaf-570d42b7fbaa"
+Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"

--- a/examples/ornstein_uhlenbeck.jl
+++ b/examples/ornstein_uhlenbeck.jl
@@ -1,0 +1,24 @@
+@everywhere using DifferentialEquations: WienerProcess, SDEProblem, solve
+# Stand-in for a more complex Model - returns necessary RHS functions, parameters
+@everywhere function ornstein_uhlenbeck1D_model(θ, σ, t0)
+    function deterministic_tendency!(dudt,u,p,t)
+        dudt .= -p.θ *u 
+    end
+    function stochastic_tendency!(dudW,u,p,t)
+        dudW .= p.σ
+    end
+    p = (θ = 1.0, σ = 1.0)
+    return deterministic_tendency!, stochastic_tendency!, p
+end
+# Sets up the simulation - whatever your problem needs to be integrated
+# forwards in time with output saved every dt, given IC, tspan,
+# and other sim_kwargs
+
+@everywhere function evolve_ornstein_uhlenbeck1D(u0, tspan, dt, alg_kwargs)
+    deterministic_tendency!, stochastic_tendency!, p = ornstein_uhlenbeck1D_model(1.0,1.0, tspan[1])
+    W0 = randn()*dt
+    dW = WienerProcess(tspan[1], W0,0.0)
+    prob = SDEProblem(deterministic_tendency!, stochastic_tendency!, u0, tspan, p, noise = dW)
+    sol = solve(prob, dt = dt, saveat = tspan[1]:dt:tspan[2]; alg_kwargs...);
+    return sol.u
+end

--- a/examples/ornstein_uhlenbeck_algorithm.jl
+++ b/examples/ornstein_uhlenbeck_algorithm.jl
@@ -4,13 +4,13 @@ using RareEvents
 using Statistics
 using SpecialFunctions
 using Distributed
-include("./examples/ornstein_uhlenbeck.jl")
+include("./ornstein_uhlenbeck.jl")
 
 dt = 0.1
 # pmap wants a function with a single argument. We iterate over ensemble
 # members (initial conditions) with fixed tspan for each
 alg_kwargs = ();
-@everywhere evolve_wrapper(tspan) = (u0) -> evolve_ornstein_uhlenbeck1D(u0, tspan, dt; alg_kwargs...)
+@everywhere evolve_wrapper(tspan) = (u0) -> evolve_ornstein_uhlenbeck1D(u0, tspan, dt, alg_kwargs)
 
 n_processes = Sys.CPU_THREADS
 addprocs(n_processes)
@@ -46,9 +46,14 @@ for i in 1:N
 end
 
 event_magnitude, rtn = return_curve(moving_average_matrix, T_a-T, p_n1);
-plot()
+plot1 = plot()
 plot!(log10.(rtn), event_magnitude, ylim = [0,1.0], xlim = [0,15], color = "red", label = "k = 0.3, N=3e3", yticks = [0,0.4,0.8])
 
+
+μ, σ = ensemble_statistics(sim.ensemble, 1)
+plot2 = plot(0.0:dt:T_a,μ,grid=false,ribbon=σ,fillalpha=.5)
+plot(plot1, plot2)
+#=
 ### Analytic estimate does not work yet
 σ = 0.142 # Computed standard deviation of moving average of x(t), from a direct integration,
 # over time T=50. It has a mean of 0. This is independent of dt if dt is small enough.
@@ -81,3 +86,4 @@ plot!(log10.(analytic_rtn), event_magnitude, color = "blue", label = "analytic e
 # The analytic expectation is FOR the moving average, not the max?
 # P_k(max(Y) = η) ∝ (q choose 1 ) F_k(η)^(q-1) P_k(η) ?
 # where F_k(η) is the cumulative distribution ∫_-∞^η P_k(s) ds
+=#

--- a/examples/ornstein_uhlenbeck_algorithm.jl
+++ b/examples/ornstein_uhlenbeck_algorithm.jl
@@ -1,38 +1,55 @@
 using Revise
-using DifferentialEquations
+using Distributed
+
+@everywhere using DifferentialEquations: WienerProcess, SDEProblem, solve
+
 using Plots
 using RareEvents
 using Statistics
 using SpecialFunctions
-function deterministic_tendency!(dudt,u,p,t)
-    dudt .= -p.θ *u 
+
+sim_kwargs = (dt = 0.1,);
+@everywhere function ornstein_uhlenbeck1D_model(θ, σ, t0)
+    function deterministic_tendency!(dudt,u,p,t)
+        dudt .= -p.θ *u 
+    end
+    function stochastic_tendency!(dudW,u,p,t)
+        dudW .= p.σ
+    end
+    p = (θ = 1.0, σ = 1.0)
+    return deterministic_tendency!, stochastic_tendency!, p
 end
 
-function stochastic_tendency!(dudW,u,p,t)
-    dudW .= p.σ
+@everywhere function ornstein_uhlenbeck1D_simulation(u0, tspan; dt = dt)
+    deterministic_tendency!, stochastic_tendency!, p = ornstein_uhlenbeck1D_model(1.0,1.0, tspan[1])
+    W0 = rand()*dt
+    dW = WienerProcess(tspan[1], W0,0.0)#, reseed = false)
+    prob = SDEProblem(deterministic_tendency!, stochastic_tendency!, u0, tspan, p, noise = dW)
+    sol = solve(prob, dt = dt, saveat = tspan[1]:dt:tspan[2]);
+    return sol.u
 end
-t0 = 0.0
-W0 = 0.0
-p = (θ = 1.0, σ = 1.0)
-dW = WienerProcess(t0, W0,0.0)#, reseed = false)
-dt = 0.1
+# Needed for pmap...
+@everywhere simulation_wrapper(tspan) = (u0) -> ornstein_uhlenbeck1D_simulation(u0, tspan; sim_kwargs...)
+
+n_processes = Sys.CPU_THREADS
+addprocs(n_processes)
+
+
 τ = 0.5
-Nτ = Int(round(τ/dt))
+Nτ = Int(round(τ/sim_kwargs.dt))
 T_a = 150.0
 N = 3000
 d = 1
 u0 = zeros(d)
 k = 0.3
 ϵ = 0.0
-# Note - your score function has to handle the dimensionality of your state vector
-score_function(x; k = k, dt = dt) = exp.(k .*sum(x[2:end]+x[1:end-1])/2.0*dt)
-# Note that the tspan and u0 will be replaced after each interval τ according to algorithm; 
-sde_ensemble_prob = SDEProblem(deterministic_tendency!, stochastic_tendency!, u0, (0,1),p, noise= dW)
-sim = RareEventSampler{Float64}(dt, d, (0.0, T_a), N, Nτ, sde_ensemble_prob, score_function, ϵ);
+score_function(x; k = k, dt =sim_kwargs.dt) = exp.(k .*sum(x[2:end]+x[1:end-1])/2.0*dt)
 
-run!(sim, u0);
+sim = RareEventSampler{Float64}(sim_kwargs.dt, d, u0, (0.0, T_a), N, Nτ, simulation_wrapper, score_function, ϵ);
+
+run!(sim);
 T = 50
-NT = Int64.(round(T/dt))
+NT = Int64.(round(T/sim_kwargs.dt))
 moving_average_matrix = zeros((N, length(sim.ensemble[1])-NT))
 moving_average_row = zeros(length(sim.ensemble[1])-NT)
 p_n1 = zeros(N)
@@ -45,14 +62,12 @@ for i in 1:N
     moving_average_row .= moving_average_matrix[i,:]
     moving_average!(moving_average_row, sol, NT)
     moving_average_matrix[i,:] .= moving_average_row
-    p_n1[i] = po_over_pk(sol, dt, T_a, k, λ)
+    p_n1[i] = po_over_pk(sol, sim_kwargs.dt, T_a, k, λ)
 end
 
 event_magnitude, rtn = return_curve(moving_average_matrix, T_a-T, p_n1);
 plot()
 plot!(log10.(rtn), event_magnitude, ylim = [0,1.0], xlim = [0,15], color = "red", label = "k = 0.3, N=3e3", yticks = [0,0.4,0.8])
-
-
 
 ### Analytic estimate does not work yet
 σ = 0.142 # Computed standard deviation of moving average of x(t), from a direct integration,

--- a/examples/ornstein_uhlenbeck_direct.jl
+++ b/examples/ornstein_uhlenbeck_direct.jl
@@ -1,80 +1,27 @@
-using DifferentialEquations
-using DifferentialEquations.EnsembleAnalysis
 using Plots
 using RareEvents
 using Statistics
+include("./examples/ornstein_uhlenbeck.jl")
 
-function deterministic_tendency!(dudt,u,p,t)
-    dudt .= -p.θ *u 
-end
-
-function stochastic_tendency!(dudW,u,p,t)
-    # adds additive noise p.σ dW_t
-    # Note that for a Weiner process, this is draws from
-    # p.σ N(0,dt)
-    dudW .= p.σ
-end
-#=
-for i in 1:8
-    t0 =0.0
-    W0 = 0.0
-    u0 = [0.0,]
-    p = (θ = 1.0, σ = 1.0)
-    dW = WienerProcess(t0, W0,0.0, reseed = false)
-    
-    tf = 1e4
-    tspan = (t0,tf)
-    dt = timestep[i]
-    T = 50
-    Δt_save = dt
-    NT = Int64.(round(T/Δt_save))
-    
-    prob = SDEProblem(deterministic_tendency!, stochastic_tendency!, u0, tspan,p, noise= dW)
-    sol= solve(prob, dt = dt, saveat = 0:Δt_save:tf, maxiters = 1e7);# what's the deal with max_iter needing to be > nsteps?
-    u = [sol.u[k][1] for k in 1:length(sol.t)-1]
-    # u has the same statistics regardless of dt. that's expected!
-    
-    A = zeros(length(u)-NT)
-    moving_average!(A,u,NT)
-    σ[i] = std(A)
-end
-σ = zeros(8)
-timestep = [0.003, 0.01,0.03,0.1,0.3,1.0,3.0,10.0]
-# even dt = 1 is fine!
- 0.13980975581577174
- 0.14255180746457424
- 0.14119076130224256
- 0.14202238113746662
- 0.14218398288278097
- 0.13794906633002438
- 0.19384396356049075
- 0.2834163945433053
-=#
-
+# Carry out integration
 t0 =0.0
-W0 = 0.0
-u0 = [0.0,]
-p = (θ = 1.0, σ = 1.0)
-dW = WienerProcess(t0, W0,0.0, reseed = false)
-
 tf = 1e4
 tspan = (t0,tf)
 dt = 1.0
 T = 50
 Δt_save = dt
 NT = Int64.(round(T/Δt_save))
+alg_kwargs = (; maxiters = 1e7,)
+direct_solution = evolve_ornstein_uhlenbeck1D(u0, tspan, dt, alg_kwargs)
+u = [direct_solution[k][1] for k in 1:length(direct_solution)]
+t = Array(t0:dt:tf)
 
-prob = SDEProblem(deterministic_tendency!, stochastic_tendency!, u0, tspan,p, noise= dW)
-sol= solve(prob, dt = dt, saveat = 0:Δt_save:tf, maxiters = 1e7);# what's the deal with max_iter needing to be > nsteps?
-u = [sol.u[k][1] for k in 1:length(sol.t)-1]
-# u has the same statistics regardless of dt. that's expected!
 
-A = zeros(length(u)-NT)
+# Obtain moving average
+A = zeros(length(u)-NT-1)
 moving_average!(A,u,NT)
 
-# u basically looks like noise.
-# The moving average should also be indep of dt because it is an integral!
-# why does this depend on dt!
+# Compute return curve
 Ta = 100
 ΔT = Ta-T
 m = Int64.(round(ΔT/Δt_save))
@@ -87,4 +34,3 @@ event_magnitude, rtn = return_curve(segment_matrix, FT(ΔT), p_m)
 
 plot(log10.(rtn), event_magnitude, ylim = [0,0.8], xlim = [0,7], color = "blue", label = "dt =1.0, N_MA = 50, Direct")
 plot!(legend = :bottomright)
-

--- a/src/RareEvents.jl
+++ b/src/RareEvents.jl
@@ -14,7 +14,7 @@ using Random
 # Why does k = 0.3 give me ~a of 0.3, not 0.6? a~k?
 # How to derive their formula?
 
-export RareEventSampler, run!, moving_average!, return_curve
+export RareEventSampler, run!, moving_average!, return_curve, ensemble_statistics
 """
     moving_average!(A::Vector{FT},timeseries::Vector{FT}, window::Int)
                    where {FT<:AbstractFloat}
@@ -252,4 +252,11 @@ function sample_and_rewrite_history!(sim, u2, copies, i1, i2, i)
     sim.R[i+1] = mean(scores)
 end
 
+# This has to be modified to plot a particular index of the state vector
+function ensemble_statistics(ensemble, state_index)
+    M = map(x -> x[state_index], reduce(hcat,ensemble))
+    means = mean(M, dims = 2)
+    stds = std(M, dims = 2)
+    return means[:], stds[:]
+end
 end


### PR DESCRIPTION
To make less dependent on DifferentialEquations, remove the use of EnsembleSimulations (which conducts N integrations with different initital conditions) and replace with pmap(f, c), where `f` is a function that takes in an initial condition and integrates it forward in time, and `c` is a collection of initial conditions.