### PR TITLE
Add Kuramoto Sivashinsky simulation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.1.0"
 [deps]
 DifferentialEquations = "0c46a032-eb83-5123-abaf-570d42b7fbaa"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+FourierFlows = "2aec4490-903f-5c70-9b11-9bed06a700e1"
 HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Optim = "429524aa-4258-5aef-a3af-852621145aeb"

--- a/examples/kuramoto_sivashinsky/Model.jl
+++ b/examples/kuramoto_sivashinsky/Model.jl
@@ -1,0 +1,110 @@
+# Code for setting up the model equations to solve
+# ∂u/∂t = -∂²u/∂x² - ∂⁴u/∂x⁴ - 1/2 ∂u²/∂x
+# or, ∂u/∂t = Lu + N(u),
+# where L = -∂²/∂x² - ∂⁴/∂x⁴ and N(u) = - 1/2 ∂u²/∂x,
+# in Fourier space using FourierFlows.jl
+
+# This copies the examples in FourierFlows.
+
+# Let u(x,t) = ∫ũ(k,t) exp{i*k*x} dk
+# Then ∂ⁿu∂xⁿ = (ik)ⁿ u(x,t)
+# Subsitute this in for the linear operator,
+# and multiply each side of the equation by  exp{-i*k*x}
+# and integrate over x.
+
+# We have:
+# - ∫ ∂u/∂t exp{-i*k*x} dx = ∂∫ u exp{-i*k*x} dx/∂t = ∂ũ/∂t
+# - ∫Lu exp{-i*k*x} dx = Lũ = (k²-k⁴)ũ
+# - ∫ N(u) exp{-i*k*x} dx = -1/2 i k ∫u² exp{-i*k*x} dx
+# or
+# ∂ũ/∂t = (k²-k⁴)ũ - 1/2 ik[u^2]̃
+module Model
+using FourierFlows
+using LinearAlgebra: ldiv!, mul!
+
+export Vars, Equation, updatevars!, Params, set_u!
+# Allocate space in Vars for solution and intermediate
+# quantities.
+# k denotes a fourier transformed variable
+struct Vars{Aphys, Atrans} <: AbstractVars
+    "The solution u"
+    u :: Aphys
+    "The Fourier transform of u"
+    uk :: Atrans
+    "The Fourier transform of u²"
+    uuk :: Atrans
+end
+
+function Vars(grid)
+  Dev = typeof(grid.device)
+  T = eltype(grid)
+  @devzeros Dev T grid.nx u
+  @devzeros Dev Complex{T} grid.nkr uk uuk
+  return Vars(u, uk, uuk,)
+end
+
+"""
+    Equation(grid)
+
+Define the linear and nonlinear components of the PDE,
+in a format defined by FourierFlows.
+"""
+function Equation(grid)
+    T = eltype(grid)
+    dev = grid.device
+    # Define nonlinear function using signature required by FourierFlows
+    function calcN!(N, sol, t, clock, vars, params, grid)
+        @. N[:, 1] = - im * grid.kr *vars.uuk/2
+        dealias!(N, grid)
+        return nothing
+    end
+    # Define linear function
+    L = zeros(dev, T, (grid.nkr, 1))
+    @. L[:, 1] = grid.kr^2 - grid.kr^4
+    
+    return FourierFlows.Equation(L, calcN!, grid)
+end
+
+"""
+    updatevars!(prob)
+
+Update the intermediate variables required to compute the tendency,
+stored in prob.vars, using the solution prob.sol.
+"""
+function updatevars!(prob)
+    vars, grid, sol = prob.vars, prob.grid, prob.sol
+    @. vars.uk = sol[:, 1]
+    # use deepcopy() because irfft destroys its input
+    ldiv!(vars.u, grid.rfftplan, deepcopy(vars.uk))
+    mul!(vars.uuk, grid.rfftplan, deepcopy(vars.u .* vars.u))
+  return nothing
+end
+
+"""
+    Params <: AbstractParams
+
+This model has no parameters but we are required to pass in
+an argument of type `AbstractParams`.
+"""
+struct Params <: AbstractParams end
+
+"""
+    set_u!(prob, u0)
+
+This function takes in an initial condition and updates the 
+field prob.sol and prob.vars.
+"""
+function set_u!(prob, u0)
+  vars, grid, sol = prob.vars, prob.grid, prob.sol
+  
+  A = typeof(vars.u) # determine the type of vars.u
+  
+  ## below, e.g., A(u0) converts u0 to the same type as vars expects
+  ## (useful when u0 is a CPU array but grid.device is GPU)
+  mul!(vars.uk, grid.rfftplan, A(u0))
+  @. sol[:, 1] = vars.uk
+  updatevars!(prob)
+  return nothing
+end
+
+end

--- a/examples/kuramoto_sivashinsky/sim.jl
+++ b/examples/kuramoto_sivashinsky/sim.jl
@@ -1,0 +1,64 @@
+using FourierFlows
+using Plots
+using HDF5
+include("Model.jl")
+using .Model: Vars, Equation, Params, updatevars!, set_u!
+# Run the simulation
+dev = CPU()
+stepper = "FilteredETDRK4"
+dt = 0.1
+nx, Lx = 128, 100
+grid = OneDGrid(; nx, Lx, x0 = 0.0)
+
+vars = Vars(grid)
+equation = Equation(grid)
+
+prob = FourierFlows.Problem(equation, stepper, dt, grid, vars, Params())
+u0 = @. sin(16π * grid.x ./ Lx)
+set_u!(prob, u0)
+updatevars!(prob)
+
+# Integration time, timestep, nsteps
+# The autocorrelation time τ ~10
+# We want 3τ = 128 steps of dt_save to generate 128x128 "images" to train with
+# dt_save ∼0.2
+# 30k samples -> 3e4*(dt_save*128) = 7.68e5 
+#tspan = (0.0,1e3)
+tspan = (0.0,7.68e5)
+nsteps = Int((tspan[2]-tspan[1])/dt)
+# Saving interval, steps per interval, total # of solutions saved
+dt_save = 0.2
+n_steps_per_save = Int(round(dt_save/dt))
+savesteps = 0:n_steps_per_save:nsteps
+
+# Preallocate the solution array
+trajectory = zeros((nx, Int(nsteps/n_steps_per_save)));
+for j = 1:nsteps
+    updatevars!(prob)
+    if j ∈ savesteps
+        save_index = Int(j/n_steps_per_save)
+        trajectory[:,save_index] .= vars.u[:]
+     end
+    stepforward!(prob)
+end
+spinup = 200.0
+n_savesteps_in_spinup = Int(spinup / dt_save)
+trajectory_nospinup = trajectory[:,n_savesteps_in_spinup:end]
+#=
+Plots.heatmap(trajectory)
+Plots.savefig("sample_trajectory.png")
+lags = Array(1:1:(size(trajectory_nospinup)[2]-1)) # in units of steps
+ac = StatsBase.autocor(transpose(trajectory_nospinup), lags; demean = true)
+mean_ac = mean(ac, dims = 2)[:]
+Plots.plot(lags *dt_save, mean_ac, label = "", ylabel = "Autocorrelation Coeff", xlabel = "Lag (time)")
+Plots.savefig("autocorr.png")
+τ = maximum(lags[mean_ac .> 0.1])*dt_save
+@show τ
+Plots.heatmap(trajectory_nospinup[:,1:128], xlabel = "Time (30units)", ylabel = "Spatial DOF")
+Plots.savefig("sample_image.png")
+=#
+#Save
+fname = "./kuramoto_sivashinksy.hdf5"
+fid = h5open(fname, "w")
+fid[string("nx_$nx","Lx_$Lx","dt_$dt","dt_save_$dt_save")] = trajectory_nospinup
+close(fid)


### PR DESCRIPTION
Adds the Kuramoto-Sivashinsky simulation + dataset creation.

Parameters:
Lx = 100
nx = 128
dt = 0.1
dt_save = 0.2

From a shorter run, I found that the spinup time for the IC I chose was ~200 units of time. This is removed. (the x-axis is units of step, so 1e3 in time is 5e3 in steps of dt_save)
![sample_trajectory](https://github.com/kmdeck/RareEvents.jl/assets/65979205/2d4cf6b7-0fe1-4f31-b1a0-38e4f7a49a3e)

From the same shorter run, I found the autocorrelation time to be ~10 units of time:
![autocorr](https://github.com/kmdeck/RareEvents.jl/assets/65979205/ad008f9f-3b68-44ef-863b-394392f5e82d)

Because we want 128x128 "images", where the time per image spans ~3*autocorrelation time, we want
dt_save = 3*AC/128 = 30/128 ~ 0.2. With this, the saved trajectory can be split into size 128 blocks each corresponding to ~2.5 autocorrelation times. These images look like this:
![sample_image](https://github.com/kmdeck/RareEvents.jl/assets/65979205/b584ffc0-b389-42d4-b4b3-13c734920597)


To generate 30k 128x128 samples for training, we integrate for 7.68e5 units of time. This divided by dt_save * 128 is 30k. 
